### PR TITLE
ARCSPC-841 Removing extra metadata from request list

### DIFF
--- a/public/views/request_list/harvard_aeon/_form_item.html.erb
+++ b/public/views/request_list/harvard_aeon/_form_item.html.erb
@@ -1,0 +1,16 @@
+<% item.form_fields.each {|r| r.each {|name, value| %>
+
+  <input type="hidden" name="<%= name %>" value="<%= value %>">
+
+<% }} %>
+
+<div class="rl-ha-excluded-request-types" style="display:none">
+  <% item.ext(:excluded_request_types).multi.map do |t| %>
+    <data value="<%= t.name %>"></data>
+  <% end %>
+</div>
+
+<div>
+
+
+</div>


### PR DESCRIPTION
After adding items to My Request List, the list screen includes extra metadata that should not be exposed to the user.  The undesired tabular data has been removed in our customization of the form below that overrides the form in the request_list plugin (https://github.com/hudmol/request_list/blob/master/public/views/request_list/harvard_aeon/_form_item.html.erb)