### PR TITLE
Remove spurious id to align with core

### DIFF
--- a/public/views/resources/infinite.html.erb
+++ b/public/views/resources/infinite.html.erb
@@ -23,9 +23,9 @@
 <%= javascript_include_tag 'largetree' %>
 <%= javascript_include_tag 'tree_renderer' %>
 
-<div class="row" id="tabs">
+<div class="row">
   <div class="col-sm-9 col-sm-push-3">
-   <%= render partial: 'resources/resource_alltabs' %>    
+   <%= render partial: 'resources/resource_alltabs' %>
     <div class="infinite-record-wrapper row">
       <div class="infinite-record-container">
           <div class="root">


### PR DESCRIPTION
Remove id="tabs" because core did it.